### PR TITLE
initial commit of bartapi package

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,96 @@
+// Copyright 2015 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package bartapi
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"code.google.com/p/go-charset/charset"
+
+	// for the charset package we need to load
+	// the data in for it to use.
+	_ "code.google.com/p/go-charset/data"
+)
+
+const (
+	// PublicAPIKey is the public key provided by BART for unregistered
+	// use of their API. To note, by using this key you automatically
+	// agree to their license agreement.
+	PublicAPIKey = "MW9S-E7SL-26DU-VV8V"
+
+	// URL is the base URL for the API endpoint
+	URL = "http://api.bart.gov/api/bsa.aspx"
+)
+
+// Client is the BART API client
+type Client struct {
+	key, baseURL string
+}
+
+// New returns a new BART API client.
+func New(key string) *Client {
+	return &Client{key: key, baseURL: URL}
+}
+
+// SetBaseURL sets the base URL for the API client.
+// "Base" meaning where the query params are passed.
+func (c *Client) SetBaseURL(u string) {
+	c.baseURL = u
+}
+
+// BaseURL returns the base URL of the client.
+func (c *Client) BaseURL() string {
+	return c.baseURL
+}
+
+// Key returns the API key of the client.
+func (c *Client) Key() string {
+	return c.key
+}
+
+// Pull does an HTTP GET request against the API endpoint.
+// You need to provide the command (cmd) to send the API.
+// You can add more query params using the "query" map
+// if you need to, otherwise use nil.
+func (c *Client) Pull(cmd string, query map[string]string) ([]byte, error) {
+	var params bytes.Buffer
+
+	params.WriteString(fmt.Sprintf("%v?cmd=%v&key=%v", c.baseURL, cmd, c.key))
+
+	for k, v := range query {
+		params.WriteString(fmt.Sprintf("&%v=%v", k, v))
+	}
+
+	resp, err := http.Get(params.String())
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+// Decode is a function to help with decoding the XML provided by BART.
+// Because of their encoding format, we need to set the CharsetReader in
+// this function. r is the data to parse, and v is data structure
+// to parse it in to.
+func Decode(r io.Reader, v interface{}) error {
+	d := xml.NewDecoder(r)
+	d.CharsetReader = charset.NewReader
+	return d.Decode(v)
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,134 @@
+// Copyright 2015 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package bartapi_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/theckman/go-bart/api"
+	. "gopkg.in/check.v1"
+)
+
+var exampleXml = `
+<root>
+	<somekey>hello!</somekey>
+</root>
+`
+
+type xmlType struct {
+	XMLName xml.Name `xml:"root"`
+	Some    string   `xml:"somekey"`
+}
+
+func Test(t *testing.T) { TestingT(t) }
+
+type TestSuite struct {
+	srv *httptest.Server
+	url string
+	c   *bartapi.Client
+}
+
+var _ = Suite(&TestSuite{})
+
+func (t *TestSuite) SetUpTest(c *C) {
+	h := &handler{}
+	t.srv = httptest.NewServer(h)
+	t.url = t.srv.URL
+	t.c = bartapi.New("testkey")
+}
+
+func (t *TestSuite) TearDownTest(c *C) {
+	t.srv.Close()
+}
+
+func (t *TestSuite) TestSetBaseURL(c *C) {
+	t.c.SetBaseURL("http://localhost")
+	url := t.c.BaseURL()
+	c.Check(url, Equals, "http://localhost")
+}
+
+func (t *TestSuite) TestKey(c *C) {
+	k := "madness"
+	cl := bartapi.New(k)
+	c.Check(cl.Key(), Equals, k)
+}
+
+func (t *TestSuite) TestPull(c *C) {
+	c.Assert(t.c.Key(), Equals, "testkey")
+
+	t.c.SetBaseURL(fmt.Sprintf("%v/", t.url))
+	c.Assert(t.c.BaseURL(), Equals, fmt.Sprintf("%v/", t.url))
+
+	resp, err := t.c.Pull("test", nil)
+	c.Assert(err, IsNil)
+
+	var j map[string]interface{}
+
+	err = json.Unmarshal(resp, &j)
+	c.Assert(err, IsNil)
+
+	// need to type assert the value from an interface{} to a string
+	c.Check((j["key"]).(string), Equals, "testkey")
+	c.Check((j["cmd"]).(string), Equals, "test")
+
+	params := make(map[string]string)
+	params["bacon"] = "good"
+	params["salad"] = "bad"
+
+	resp, err = t.c.Pull("test2", params)
+	c.Assert(err, IsNil)
+
+	j = make(map[string]interface{})
+
+	err = json.Unmarshal(resp, &j)
+	c.Assert(err, IsNil)
+	c.Check((j["key"]).(string), Equals, "testkey")
+	c.Check((j["cmd"]).(string), Equals, "test2")
+	c.Check((j["bacon"]).(string), Equals, "good")
+	c.Check((j["salad"]).(string), Equals, "bad")
+}
+
+func (t *TestSuite) TestDecode(c *C) {
+	r := bytes.NewReader([]byte(exampleXml))
+	x := &xmlType{}
+
+	err := bartapi.Decode(r, x)
+	c.Assert(err, IsNil)
+	c.Check(x.Some, Equals, "hello!")
+
+	r = bytes.NewReader([]byte(""))
+	x = &xmlType{}
+
+	err = bartapi.Decode(r, x)
+	c.Assert(err, Not(IsNil))
+}
+
+type handler struct{}
+
+func (*handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	err := req.ParseForm()
+	if err != nil {
+		panic(err.Error())
+	}
+	params := make(map[string]string)
+
+	for k, v := range req.Form {
+		params[k] = v[0]
+	}
+
+	resp, err := json.Marshal(params)
+
+	if err != nil {
+		panic(err.Error())
+	}
+
+	fmt.Fprintf(rw, string(resp))
+}


### PR DESCRIPTION
The `bartapi` package is the package used for making the HTTP requests to the BART API. It also has a `Decoder()` function meant to me used for decoding XML.

Other packages will use this to make requests to the BART API.
